### PR TITLE
Add browser-based C++ editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# Browser-based C++ Editor
+
+This project provides a single page C++ editor that compiles and runs code
+entirely in the browser. It uses the [Monaco editor](https://microsoft.github.io/monaco-editor/)
+and [`wasm-clang`](https://github.com/binji/wasm-clang) to compile C++ to WebAssembly.
+The compiled module executes in a Web Worker and its output is shown in a console.
+
+## Features
+
+- Material Design layout with Monaco editor
+- Split view with resizable output panel
+- Console and input tabs. Text typed in the input tab is provided on `stdin`.
+- Compilation and execution happen in a Web Worker so the UI stays responsive.
+
+## Running
+
+Open `index.html` in a browser. No server is required, but all assets must be
+served over HTTP(s). The worker downloads the compiler toolchain from
+`https://binji.github.io/wasm-clang/`.
+
+To deploy on GitHub Pages or similar static hosts simply publish the repository
+contents. If the hosting platform allows custom headers you can serve the page
+with `Cross-Origin-Opener-Policy: same-origin` and
+`Cross-Origin-Embedder-Policy: require-corp` to enable `SharedArrayBuffer` in the
+future, but the current toolchain does **not** require these headers.
+
+## Acknowledgements
+
+The WebAssembly-based compiler is provided by the
+[wasm-clang project](https://github.com/binji/wasm-clang) and is licensed under
+Apache 2.0.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Browser C++ Editor</title>
+  <!-- Material Design Components -->
+  <link rel="stylesheet" href="https://unpkg.com/material-components-web@latest/dist/material-components-web.min.css">
+  <script defer src="https://unpkg.com/material-components-web@latest/dist/material-components-web.min.js"></script>
+  <!-- Monaco -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.44.0/min/vs/loader.min.js"></script>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body class="mdc-typography">
+  <header class="mdc-top-app-bar mdc-top-app-bar--fixed">
+    <div class="mdc-top-app-bar__row">
+      <section class="mdc-top-app-bar__section mdc-top-app-bar__section--align-start">
+        <span class="mdc-top-app-bar__title">C++ Web Editor</span>
+      </section>
+      <section class="mdc-top-app-bar__section mdc-top-app-bar__section--align-end" role="toolbar">
+        <button id="run" class="mdc-button mdc-button--raised">
+          <span class="mdc-button__label">Run</span>
+        </button>
+      </section>
+    </div>
+  </header>
+
+  <div class="main-content">
+    <div id="editor" class="editor"></div>
+    <div id="resizer" class="resizer"></div>
+    <div id="bottom-pane" class="bottom-pane">
+      <div class="tabs">
+        <button id="tab-console" class="tab active">Console</button>
+        <button id="tab-input" class="tab">Input</button>
+      </div>
+      <div id="console-panel" class="panel active"><pre id="output"></pre></div>
+      <div id="input-panel" class="panel"><textarea id="stdin" placeholder="Program input..."></textarea></div>
+    </div>
+  </div>
+
+  <script src="main.js"></script>
+</body>
+</html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,64 @@
+// Initialize Material components
+window.mdc && mdc.autoInit();
+
+// Monaco setup
+require.config({ paths: { 'vs': 'https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.44.0/min/vs' } });
+let editor;
+require(['vs/editor/editor.main'], function () {
+  editor = monaco.editor.create(document.getElementById('editor'), {
+    value: '#include <iostream>\nint main(){\n    std::string name;\n    std::getline(std::cin, name);\n    std::cout << "Hello " << name << "!" << std::endl;\n}\n',
+    language: 'cpp',
+    theme: 'vs-dark',
+    automaticLayout: true
+  });
+});
+
+// Worker setup
+const worker = new Worker('worker.js');
+const output = document.getElementById('output');
+worker.onmessage = (e) => {
+  const { type, data } = e.data;
+  if (type === 'stdout' || type === 'stderr') {
+    output.textContent += data;
+  }
+};
+
+// Run button
+document.getElementById('run').addEventListener('click', () => {
+  output.textContent = '';
+  const code = editor.getValue();
+  const input = document.getElementById('stdin').value;
+  worker.postMessage({ code, input });
+  setActiveTab('console');
+});
+
+// Tabs
+function setActiveTab(tab) {
+  document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
+  document.querySelectorAll('.panel').forEach(p => p.classList.remove('active'));
+  if (tab === 'console') {
+    document.getElementById('tab-console').classList.add('active');
+    document.getElementById('console-panel').classList.add('active');
+  } else {
+    document.getElementById('tab-input').classList.add('active');
+    document.getElementById('input-panel').classList.add('active');
+  }
+}
+
+document.getElementById('tab-console').addEventListener('click', () => setActiveTab('console'));
+document.getElementById('tab-input').addEventListener('click', () => setActiveTab('input'));
+
+// Resizer
+const resizer = document.getElementById('resizer');
+const bottomPane = document.getElementById('bottom-pane');
+const mainContent = document.querySelector('.main-content');
+let isResizing = false;
+
+resizer.addEventListener('mousedown', () => { isResizing = true; });
+document.addEventListener('mousemove', (e) => {
+  if (!isResizing) return;
+  const mainRect = mainContent.getBoundingClientRect();
+  const newHeight = mainRect.bottom - e.clientY;
+  bottomPane.style.height = Math.max(100, newHeight) + 'px';
+});
+document.addEventListener('mouseup', () => { isResizing = false; });

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,72 @@
+html, body {
+  height: 100%;
+  margin: 0;
+}
+
+.main-content {
+  position: absolute;
+  top: 64px; /* height of app bar */
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.editor {
+  flex: 1;
+}
+
+.resizer {
+  height: 5px;
+  background: #e0e0e0;
+  cursor: row-resize;
+}
+
+.bottom-pane {
+  height: 200px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.tabs {
+  display: flex;
+  background: #f5f5f5;
+}
+
+.tab {
+  flex: 1;
+  padding: 4px 8px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+}
+
+.tab.active {
+  background: #e0e0e0;
+}
+
+.panel {
+  flex: 1;
+  display: none;
+  overflow: auto;
+  background: #121212;
+  color: #ffffff;
+}
+
+.panel.active {
+  display: block;
+}
+
+#output {
+  padding: 8px;
+  white-space: pre-wrap;
+}
+
+#stdin {
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box;
+  padding: 8px;
+}

--- a/worker.js
+++ b/worker.js
@@ -1,0 +1,29 @@
+const base = 'https://binji.github.io/wasm-clang/';
+
+importScripts(base + 'shared.js');
+
+const api = new API({
+  readBuffer: async (path) => {
+    const response = await fetch(base + path);
+    return response.arrayBuffer();
+  },
+  compileStreaming: async (path) => {
+    if (WebAssembly.compileStreaming) {
+      return WebAssembly.compileStreaming(fetch(base + path));
+    }
+    const response = await fetch(base + path);
+    return WebAssembly.compile(await response.arrayBuffer());
+  },
+  hostWrite: (s) => postMessage({ type: 'stdout', data: s })
+});
+
+onmessage = async (e) => {
+  const { code, input } = e.data;
+  try {
+    api.memfs.setStdinStr(input || '');
+    await api.compileLinkRun(code);
+    postMessage({ type: 'done' });
+  } catch (err) {
+    postMessage({ type: 'stderr', data: err.toString() + '\n' });
+  }
+};


### PR DESCRIPTION
## Summary
- Add single-page Material-styled C++ editor with Monaco and resizable console
- Compile and run C++ in a Web Worker using wasm-clang fetched at runtime
- Provide basic README with hosting and header considerations

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_6897396a1cd88322b7b2338b0ddc100c