### PR TITLE
Improve console pane resizing

### DIFF
--- a/main.js
+++ b/main.js
@@ -51,16 +51,14 @@ document.getElementById("tab-console").addEventListener("click", () => setActive
 document.getElementById("tab-input").addEventListener("click", () => setActiveTab("input"));
 
 // Pane size controls
-const editorContainer = document.getElementById("editor");
 const bottomPane = document.getElementById("bottom-pane");
 
-function setPaneSizes(editorPercent, bottomPercent) {
-  editorContainer.style.flex = `0 0 ${editorPercent}%`;
-  bottomPane.style.flex = `0 0 ${bottomPercent}%`;
+function setBottomHeight(percent) {
+  bottomPane.style.height = `${percent}%`;
   if (editor) editor.layout();
 }
 
-document.getElementById("maximize").addEventListener("click", () => setPaneSizes(20, 80));
-document.getElementById("minimize").addEventListener("click", () => setPaneSizes(30, 70));
+document.getElementById("maximize").addEventListener("click", () => setBottomHeight(50));
+document.getElementById("minimize").addEventListener("click", () => setBottomHeight(15));
 
-setPaneSizes(20, 80);
+setBottomHeight(25);

--- a/styles.css
+++ b/styles.css
@@ -14,11 +14,12 @@ html, body {
 }
 
 .editor {
-  flex: 0 0 20%;
+  flex: 1 1 auto;
 }
 
 .bottom-pane {
-  flex: 0 0 80%;
+  flex: 0 0 auto;
+  height: 25%;
   display: flex;
   flex-direction: column;
   overflow: hidden;


### PR DESCRIPTION
## Summary
- Allocate more vertical space to the editor and manage console height via `height`
- Rework pane resize controls to minimize or maximize the console panel

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68974c827c348322b9ac430db70509fb