### PR TITLE
Improve console pane resizing and output visibility

### DIFF
--- a/main.js
+++ b/main.js
@@ -21,6 +21,7 @@ worker.onmessage = (e) => {
   if (type === "stdout" || type === "stderr") {
     const clean = data.replace(/\x1b\[1;93m>\x1b\[0m/g, "> ");
     output.textContent += clean;
+    output.parentElement.scrollTop = output.parentElement.scrollHeight;
   }
 };
 
@@ -54,7 +55,7 @@ document.getElementById("tab-input").addEventListener("click", () => setActiveTa
 const bottomPane = document.getElementById("bottom-pane");
 
 function setBottomHeight(percent) {
-  bottomPane.style.height = `${percent}%`;
+  bottomPane.style.flexBasis = `${percent}%`;
   if (editor) editor.layout();
 }
 

--- a/styles.css
+++ b/styles.css
@@ -15,11 +15,11 @@ html, body {
 
 .editor {
   flex: 1 1 auto;
+  min-height: 0;
 }
 
 .bottom-pane {
-  flex: 0 0 auto;
-  height: 25%;
+  flex: 0 0 25%;
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -61,6 +61,7 @@ html, body {
   overflow: auto;
   background: #121212;
   color: #ffffff;
+  min-height: 0;
 }
 
 .panel.active {


### PR DESCRIPTION
## Summary
- Ensure editor and console panes resize without triggering page scrolling
- Automatically scroll the console to show the latest output

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689752b3a57083229d7ac5cb55cc55a0