### PR TITLE
Expand options modal and add credits section

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -85,10 +85,23 @@
 
     <div id="options-modal" class="modal">
       <div class="modal-content">
-        <label>
+        <h2 class="modal-header">Options</h2>
+        <label class="modal-option">
           <input type="checkbox" id="use-fixed-inputs" />
           Use fixed inputs
         </label>
+        <h2 class="modal-header modal-header--credits">Credits</h2>
+        <p class="credits-text">
+          This editor is for educational purposes and uses the LLVM toolchain:
+          Clang and LLD (Apache-2.0 WITH LLVM-exception). Wasm build approach
+          and FS glue adapted from
+          <a href="https://github.com/binji/wasm-clang">binji/wasm-clang</a>
+          (Apache-2.0). Source:
+          <a href="https://github.com/bakerpdgit/CppEditor">GitHub</a> •
+          Upstream:
+          <a href="https://github.com/binji/wasm-clang">wasm-clang</a> •
+          <a href="https://llvm.org/">LLVM</a>
+        </p>
         <div class="modal-actions">
           <button id="options-ok">OK</button>
         </div>

--- a/public/styles.css
+++ b/public/styles.css
@@ -127,11 +127,33 @@ html, body {
   padding: 16px;
   border-radius: 4px;
   color: #000000;
+  width: 420px;
+  max-width: 90%;
 }
 
 .modal-actions {
   margin-top: 12px;
   text-align: right;
+}
+
+.modal-header {
+  margin: 0 0 8px;
+  font-size: 1.25rem;
+}
+
+.modal-header--credits {
+  margin-top: 16px;
+}
+
+.credits-text {
+  font-size: 0.875rem;
+  line-height: 1.4;
+  margin: 0;
+}
+
+.modal-option {
+  display: block;
+  margin-bottom: 8px;
 }
 
 .inputs-area {


### PR DESCRIPTION
## Summary
- widen options modal for better readability
- add styled headers for Options and Credits
- include credits statement with links to project and upstream sources

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_b_6898e1645bd88322badb34096f366d37