### PR TITLE
Fix editor top offset

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -48,7 +48,7 @@
       </div>
     </header>
 
-    <div class="main-content">
+    <div class="main-content mdc-top-app-bar--fixed-adjust">
       <div id="editor" class="editor"></div>
       <div id="bottom-pane" class="bottom-pane">
         <div class="console-controls">

--- a/public/styles.css
+++ b/public/styles.css
@@ -5,7 +5,7 @@ html, body {
 
 .main-content {
   position: absolute;
-  top: 64px; /* height of app bar */
+  top: 0;
   left: 0;
   right: 0;
   bottom: 0;


### PR DESCRIPTION
## Summary
- ensure main editor content is offset below the top app bar
- remove fixed 64px top offset and use Material's fixed-adjust class for responsiveness

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_b_6898e83fdd308322ac13ddea4b329cf0